### PR TITLE
fix: tratar links da janela de atualização e remover onclick inline

### DIFF
--- a/src/scripts/updater.js
+++ b/src/scripts/updater.js
@@ -18,9 +18,31 @@ const downloadPercent = document.getElementById('download-percent');
 const downloadStatus = document.getElementById('download-status');
 const changelogContainer = document.getElementById('changelog-container');
 const changelogContent = document.getElementById('changelog-content');
+const DOWNLOAD_PAGE_URL = 'https://www.reccorder.com.br';
 
 /** @type {Function|undefined} Função de callback para desvincular o listener dos dados. */
 let unlistenData;
+
+/**
+ * Intercepta links dentro de um container para abrir no navegador externo.
+ * @param {HTMLElement} container
+ */
+function attachExternalLinkHandler(container) {
+  if (!container || container.dataset.externalLinkHandlerAttached === 'true') return;
+
+  container.addEventListener('click', (event) => {
+    const link = event.target.closest('a');
+    if (!link) return;
+
+    const href = link.getAttribute('href');
+    if (!href) return;
+
+    event.preventDefault();
+    recorder.openLink(href);
+  });
+
+  container.dataset.externalLinkHandlerAttached = 'true';
+}
 
 /**
  * Inicializa a janela do atualizador e aguarda dados do backend.
@@ -138,6 +160,8 @@ async function init() {
         if (window.Prism) {
           window.Prism.highlightAllUnder(changelogContent);
         }
+
+        attachExternalLinkHandler(changelogContent);
       } else {
         changelogContent.textContent = processedBody;
       }
@@ -213,9 +237,11 @@ function showError(error) {
     <div class="error-text">
       Não foi possível concluir a atualização automática.<br>
       Por favor, baixe a versão mais recente manualmente em: 
-      <span class="download-link" onclick="import('./recorder.js').then(r => r.invoke('open_link', { url: 'https://www.reccorder.com.br' }))">www.reccorder.com.br</span>
+      <a class="download-link" href="${DOWNLOAD_PAGE_URL}">www.reccorder.com.br</a>
     </div>
   `;
+
+  attachExternalLinkHandler(statusText);
   
   btnInstall.classList.add('hidden');
   btnCancel.textContent = 'Fechar';


### PR DESCRIPTION
### Motivation
- Corrigir o comportamento de links na janela de atualizações que não abriam de forma segura no navegador externo, conforme relatado na Issue #7.
- Remover o uso de `onclick` inline e centralizar a abertura de links via API segura do app para evitar comportamento inconsistentes e duplicação de handlers.

### Description
- Adiciona a constante `DOWNLOAD_PAGE_URL` e converte o link de erro para uma âncora normal `<a>` apontando para essa URL no arquivo `src/scripts/updater.js`.
- Implementa a função reutilizável `attachExternalLinkHandler(container)` que intercepta cliques em links dentro de um container e chama `recorder.openLink(href)`.
- Anexa o handler ao `changelogContent` após a renderização do Markdown e também ao `statusText` no estado de erro, evitando múltiplas ligações graças a uma flag em `dataset.externalLinkHandlerAttached`.
- Substitui o `onclick` inline por tratamento centralizado, tornando o código mais seguro, testável e consistente entre as views.

### Testing
- Executado `node --check src/scripts/updater.js` para verificação de sintaxe e o comando retornou sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea583d2fc4832e8e993bda431955c5)